### PR TITLE
docs: gpt-realtime-2 GA Realtime STS guide (AVR-267)

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -9,6 +9,44 @@ dateCreated: 2025-08-08T16:52:47.453Z
 ---
 
 
+> 24 May 2026
+> {.is-info}
+{.is-info}
+
+:rocket: **OpenAI STS upgraded to GA Realtime — `gpt-realtime-2` is here!**
+
+Hi @everyone :wave:
+
+We're excited to announce **`avr-sts-openai: 1.11.0`**, a major upgrade to OpenAI's **GA Realtime API** with the latest speech-to-speech model.
+
+### What's new?
+
+The OpenAI STS connector now targets the production GA Realtime interface:
+
+* Default model **`gpt-realtime-2`** (configurable via `OPENAI_MODEL`)
+* GA session schema with nested `audio` input/output configuration
+* GA event handling (`response.output_audio.delta`, transcripts, tool calls)
+* Configurable **turn detection** — `server_vad` by default (`OPENAI_TURN_DETECTION`)
+* Optional **reasoning effort** for `gpt-realtime-2` (`OPENAI_REASONING_EFFORT`)
+* Deprecated beta models (e.g. `gpt-4o-realtime-preview`) are **rejected** with a clear error
+
+### Why this matters
+
+* **Better voice quality and instruction following** with OpenAI's latest realtime model
+* **Production-ready GA API** — no beta header required
+* **Safer telephony UX** — `server_vad` default preserves familiar turn-taking behavior
+* **Clear migration path** — breaking changes documented; override model for `gpt-realtime` or `gpt-realtime-mini`
+
+### What has been updated
+
+* **avr-sts-openai** `1.11.0` — GA Realtime migration
+  https://github.com/agentvoiceresponse/avr-sts-openai
+
+* **Updated guide:** OpenAI Realtime Speech-to-Speech (STS)
+  https://wiki.agentvoiceresponse.com/en/using-openai-realtime-sts-with-avr
+
+> **Breaking change:** If you still use `OPENAI_MODEL=gpt-4o-realtime-preview`, update to `gpt-realtime-2` (or `gpt-realtime` / `gpt-realtime-mini`) before upgrading the connector image.
+
 > 15 February 2026
 > {.is-info}
 {.is-info}

--- a/using-openai-realtime-sts-with-avr.md
+++ b/using-openai-realtime-sts-with-avr.md
@@ -29,9 +29,9 @@ For more details on function calls, see [AVR Function Calls](https://wiki.agentv
 | OPENAI_INSTRUCTIONS   | # Method 1: Direct variable                       | "You are a helpful assistant."          |
 | *OPENAI_URL_INSTRUCTIONS   | # Method 2: Web service                       | https://your-api.com/instructions          |
 | *OPENAI_FILE_INSTRUCTIONS   | # Method 3: Local file                       | ./instructions.txt          |
-| OPENAI_TEMPERATURE    | Controls randomness in responses (0.0–1.0, default 0.8) | 0.8                                     |
-| OPENAI_MAX_TOKENS     | Maximum response length (default: unlimited)          | 100                                     |
-| OPENAI_REASONING_EFFORT | Reasoning effort for gpt-realtime-2 (`low`, `medium`, `high`) | low                              |
+| OPENAI_TEMPERATURE    | Sampling temperature for `gpt-realtime` / `gpt-realtime-mini` only (0.6–1.2) | 0.8                          |
+| OPENAI_MAX_TOKENS     | Max output tokens per response (`max_response_output_tokens`) | inf                            |
+| OPENAI_REASONING_EFFORT | Reasoning effort for `gpt-realtime-2` (`minimal`–`xhigh`) | low                              |
 | OPENAI_TRANSCRIPTION_MODEL | Model for input audio transcription              | whisper-1                               |
 | OPENAI_TURN_DETECTION   | Voice activity detection (`server_vad` or `semantic_vad`) | server_vad                         |
 | OPENAI_TURN_DETECTION_EAGERNESS | Eagerness for `semantic_vad` only (`low`, `medium`, `high`, `auto`) | (optional)              |

--- a/using-openai-realtime-sts-with-avr.md
+++ b/using-openai-realtime-sts-with-avr.md
@@ -23,7 +23,7 @@ For more details on function calls, see [AVR Function Calls](https://wiki.agentv
 |-----------------------|-------------------------------------------------------|-----------------------------------------|
 | PORT                  | Port on which the STS service runs                    | 6030                                    |
 | OPENAI_API_KEY        | Your OpenAI API key                                   | sk-xxxxxx                               |
-| OPENAI_MODEL          | OpenAI model ID to use                                | gpt-4o-realtime-preview                 |
+| OPENAI_MODEL          | OpenAI model ID to use                                | gpt-realtime-2                          |
 | OPENAI_VOICE          | Specifies the voice to use for speech synthesis                                | alloy                 |
 | OPENAI_LANGUAGE          | Specifies the language to use for speech recognition                                | auto-detected                 |
 | OPENAI_INSTRUCTIONS   | # Method 1: Direct variable                       | "You are a helpful assistant."          |
@@ -31,6 +31,10 @@ For more details on function calls, see [AVR Function Calls](https://wiki.agentv
 | *OPENAI_FILE_INSTRUCTIONS   | # Method 3: Local file                       | ./instructions.txt          |
 | OPENAI_TEMPERATURE    | Controls randomness in responses (0.0–1.0, default 0.8) | 0.8                                     |
 | OPENAI_MAX_TOKENS     | Maximum response length (default: unlimited)          | 100                                     |
+| OPENAI_REASONING_EFFORT | Reasoning effort for gpt-realtime-2 (`low`, `medium`, `high`) | low                              |
+| OPENAI_TRANSCRIPTION_MODEL | Model for input audio transcription              | whisper-1                               |
+| OPENAI_TURN_DETECTION   | Voice activity detection (`server_vad` or `semantic_vad`) | server_vad                         |
+| OPENAI_TURN_DETECTION_EAGERNESS | Eagerness for `semantic_vad` only (`low`, `medium`, `high`, `auto`) | (optional)              |
 
 ---
 
@@ -45,7 +49,7 @@ avr-sts-openai:
   environment:
     - PORT=6030
     - OPENAI_API_KEY=$OPENAI_API_KEY
-    - OPENAI_MODEL=gpt-4o-realtime-preview
+    - OPENAI_MODEL=gpt-realtime-2
     - OPENAI_INSTRUCTIONS="You are a helpful assistant."
     - OPENAI_TEMPERATURE=0.8
     - OPENAI_MAX_TOKENS=100
@@ -127,10 +131,12 @@ Below is a step-by-step guide on how to configure:
 Set your realtime model using:
 
 ```env
-OPENAI_MODEL=gpt-realtime
+OPENAI_MODEL=gpt-realtime-2
 ```
 
-This is the recommended default for streaming speech-to-speech interactions.
+This is the recommended default for streaming speech-to-speech interactions. Use `gpt-realtime` for the previous GA model, or `gpt-realtime-mini` for a lower-cost option.
+
+> **Breaking change:** `gpt-4o-realtime-preview` is no longer supported. The connector uses the GA Realtime API. Turn detection defaults to `server_vad` via `OPENAI_TURN_DETECTION` (set `semantic_vad` to opt in).
 
 ---
 
@@ -226,7 +232,7 @@ OPENAI_INSTRUCTIONS="Affect/personality: A cheerful guide \n\nTone: Friendly, cl
 ## 4. Full Example Configuration
 
 ```env
-OPENAI_MODEL=gpt-realtime
+OPENAI_MODEL=gpt-realtime-2
 OPENAI_VOICE=alloy
 OPENAI_INSTRUCTIONS="A cheerful guide who speaks clearly, with warm and supportive tone..."
 ```

--- a/using-openai-realtime-sts-with-avr.md
+++ b/using-openai-realtime-sts-with-avr.md
@@ -30,7 +30,7 @@ For more details on function calls, see [AVR Function Calls](https://wiki.agentv
 | *OPENAI_URL_INSTRUCTIONS   | # Method 2: Web service                       | https://your-api.com/instructions          |
 | *OPENAI_FILE_INSTRUCTIONS   | # Method 3: Local file                       | ./instructions.txt          |
 | OPENAI_TEMPERATURE    | Sampling temperature for `gpt-realtime` / `gpt-realtime-mini` only (0.6–1.2) | 0.8                          |
-| OPENAI_MAX_TOKENS     | Max output tokens per response (`max_response_output_tokens`) | inf                            |
+| OPENAI_MAX_TOKENS     | Max output tokens per response (`response.create` → `max_output_tokens`) | inf                 |
 | OPENAI_REASONING_EFFORT | Reasoning effort for `gpt-realtime-2` (`minimal`–`xhigh`) | low                              |
 | OPENAI_TRANSCRIPTION_MODEL | Model for input audio transcription              | whisper-1                               |
 | OPENAI_TURN_DETECTION   | Voice activity detection (`server_vad` or `semantic_vad`) | server_vad                         |


### PR DESCRIPTION
## Summary
- Update `using-openai-realtime-sts-with-avr.md` for `gpt-realtime-2` default
- Fix Docker Compose typo (`gpt-realtime-2-2` → `gpt-realtime-2`)
- Document `OPENAI_TURN_DETECTION`, reasoning effort, and breaking changes from beta preview models

## Test plan
- [ ] Review env table and compose example for correct model IDs

Related: agentvoiceresponse/avr-sts-openai PR for connector changes (AVR-267).

Made with [Cursor](https://cursor.com)