### PR TITLE
docs(release): avr-app 1.5.5 STS catalog release notes

### DIFF
--- a/administration-panel.md
+++ b/administration-panel.md
@@ -93,6 +93,26 @@ Default credentials:
 
 ---
 
+## STS providers
+
+Speech-to-Speech (STS) agents use a **Provider** record in the admin panel. Credentials and tuning live in **Provider → config.env** (saved per provider in the database). Do **not** put connector secrets in `backend/.env` — that file is only for platform services (API URL, Docker socket, Asterisk paths, admin seed).
+
+**Workflow:** Create Provider (pick STS template) → Create Agent (STS mode, select provider) → assign a Number → run the agent.
+
+| Docker image | Description | Wiki |
+|---|---|---|
+| `agentvoiceresponse/avr-sts-openai` | OpenAI GA Realtime speech-to-speech | [OpenAI Realtime STS](https://wiki.agentvoiceresponse.com/en/using-openai-realtime-sts-with-avr) |
+| `agentvoiceresponse/avr-sts-elevenlabs` | ElevenLabs conversational agent STS | [ElevenLabs STS](https://wiki.agentvoiceresponse.com/en/elevenlabs-speech-to-speech-integration-avr) |
+| `agentvoiceresponse/avr-sts-gemini` | Google Gemini Live STS | [Gemini STS](https://wiki.agentvoiceresponse.com/en/using-gemini-sts-with-avr) |
+| `agentvoiceresponse/avr-sts-ultravox` | Ultravox.ai agent or generic-call STS | [STS integration](https://wiki.agentvoiceresponse.com/en/avr-sts-integration-implementation) |
+| `agentvoiceresponse/avr-sts-deepgram` | Deepgram Voice Agent (ASR + LLM + TTS) | [Deepgram](https://wiki.agentvoiceresponse.com/en/deepgram) |
+| `agentvoiceresponse/avr-sts-speechmatics` | Speechmatics Flow realtime STS | [Speechmatics](https://wiki.agentvoiceresponse.com/en/speechmatics) |
+| `agentvoiceresponse/avr-sts-humeai` | HumeAI EVI emotional voice STS | [HumeAI STS](https://wiki.agentvoiceresponse.com/en/using-humeai-sts-with-avr) |
+
+For env key parity across connectors, backend contracts, and admin templates, see `backend/docs/AVR-281-sts-env-parity.md` in the [avr-app](https://github.com/agentvoiceresponse/avr-app) repository.
+
+---
+
 ## Testing
 
 ### SIP Softphone

--- a/releases.md
+++ b/releases.md
@@ -43,6 +43,8 @@ Hi @everyone :wave:
   https://wiki.agentvoiceresponse.com/en/speechmatics
   https://wiki.agentvoiceresponse.com/en/using-humeai-sts-with-avr
 
+> **Breaking change:** Existing Deepgram STS providers created before `avr-app` `1.5.5` must add `AGENT_PROMPT` to provider config before starting an agent; the administration panel and backend now enforce this at `runAgent` time (new providers get a template default).
+
 > 24 May 2026
 > {.is-info}
 {.is-info}

--- a/releases.md
+++ b/releases.md
@@ -2,11 +2,46 @@
 title: Release Notes
 description: List of new features, bug fixes and improvement
 published: true
-date: 2026-05-24T19:15:00.000Z
+date: 2026-05-24T20:30:00.000Z
 tags: 
 editor: markdown
 dateCreated: 2025-08-08T16:52:47.453Z
 ---
+
+> 24 May 2026
+> {.is-info}
+{.is-info}
+
+:rocket: **All seven STS providers in the admin panel — `avr-app: 1.5.5`**
+
+Hi @everyone :wave:
+
+**`avr-app: 1.5.5`** completes the AVR-281 STS integration: Speechmatics and HumeAI are first-class in the administration panel, backend contracts align with connector runtime requirements, and a published env parity matrix documents all seven STS images.
+
+### What's new?
+
+* **Speechmatics STS** — create providers from template (`SPEECHMATICS_API_KEY`, EU/US region)
+* **HumeAI STS** — template with config-id mode (voice/instructions/welcome omitted when `HUMEAI_CONFIG_ID` is set)
+* **Contract alignment** — backend validates `SPEECHMATICS_API_KEY`, `HUMEAI_API_KEY`, and Deepgram `AGENT_PROMPT` before agent startup
+* **OpenAI default** — admin template default model `gpt-realtime-2` matches GA Realtime connector
+
+### Why this matters
+
+* **Operators configure STS in one place** — Provider `config.env` in the panel, not `backend/.env`
+* **Fewer silent misconfigs** — required env keys enforced at create time for all catalogued STS images
+* **Documented parity** — `backend/docs/AVR-281-sts-env-parity.md` cross-walks connectors, contracts, and templates
+
+### What has been updated
+
+* **avr-app** `1.5.5` — STS provider catalog (Speechmatics + HumeAI templates, contracts, parity matrix)
+  https://github.com/agentvoiceresponse/avr-app
+
+* **Updated guide:** AVR App – Administration Panel (STS providers subsection)
+  https://wiki.agentvoiceresponse.com/en/administration-panel
+
+* **Updated guides:** Speechmatics STS, HumeAI STS
+  https://wiki.agentvoiceresponse.com/en/speechmatics
+  https://wiki.agentvoiceresponse.com/en/using-humeai-sts-with-avr
 
 > 24 May 2026
 > {.is-info}


### PR DESCRIPTION
## Summary

- Prepend `releases.md` block for **avr-app 1.5.5** (seven STS providers in admin panel)
- Add **STS providers** subsection to `administration-panel.md` with wiki links and config path guidance

## Paperclip

- [AVR-285](https://github.com/agentvoiceresponse/avr-app/issues/285) — avr-docs administration panel STS catalog
- Release gate: [AVR-286](https://github.com/agentvoiceresponse/avr-app/issues/286)

## Test plan

- [ ] Verify wiki links resolve on publish
- [ ] Merge after or with avr-app ship PR `avr-281-sts-provider-integration`


Made with [Cursor](https://cursor.com)