### PR TITLE
docs(avr-292): avr-app 1.5.6 ASR provider release notes

### DIFF
--- a/administration-panel.md
+++ b/administration-panel.md
@@ -93,6 +93,22 @@ Default credentials:
 
 ---
 
+## ASR providers
+
+Pipeline agents (ASR + LLM + TTS) use a **Provider** record per speech-to-text connector. Credentials and tuning live in **Provider → config.env** (saved per provider in the database). Do **not** put connector secrets in `backend/.env` — that file is only for platform services (API URL, Docker socket, Asterisk paths, admin seed).
+
+**Workflow:** Create Provider (pick ASR template) → Create Agent (pipeline mode: select ASR, LLM, and TTS providers) → assign a Number → run the agent.
+
+| Docker image | Description | Wiki |
+|---|---|---|
+| `agentvoiceresponse/avr-asr-deepgram` | Deepgram streaming speech-to-text | [Deepgram](https://wiki.agentvoiceresponse.com/en/deepgram) |
+| `agentvoiceresponse/avr-asr-sarvam` | Sarvam streaming STT (Indic languages) | [Sarvam](https://wiki.agentvoiceresponse.com/en/sarvam) |
+| `agentvoiceresponse/avr-asr-soniox` | Soniox realtime speech recognition | [Soniox ASR](https://wiki.agentvoiceresponse.com/en/avr-soniox-speech-to-text) |
+
+For env key parity across connectors, backend contracts, and admin templates, see `backend/docs/AVR-290-asr-env-parity.md` in the [avr-app](https://github.com/agentvoiceresponse/avr-app) repository.
+
+---
+
 ## STS providers
 
 Speech-to-Speech (STS) agents use a **Provider** record in the admin panel. Credentials and tuning live in **Provider → config.env** (saved per provider in the database). Do **not** put connector secrets in `backend/.env` — that file is only for platform services (API URL, Docker socket, Asterisk paths, admin seed).

--- a/releases.md
+++ b/releases.md
@@ -2,11 +2,39 @@
 title: Release Notes
 description: List of new features, bug fixes and improvement
 published: true
-date: 2026-05-24T20:30:00.000Z
+date: 2026-05-24T21:00:00.000Z
 tags: 
 editor: markdown
 dateCreated: 2025-08-08T16:52:47.453Z
 ---
+
+> 24 May 2026
+> {.is-info}
+{.is-info}
+
+:rocket: **ASR provider runtime contracts — `avr-app: 1.5.6`**
+
+Hi @everyone :wave:
+
+**`avr-app: 1.5.6`** adds backend validation for three ASR connector images so operators cannot save providers missing required API keys before agents start.
+
+### What's new?
+
+* **Deepgram ASR** — `DEEPGRAM_API_KEY` required for `agentvoiceresponse/avr-asr-deepgram`
+* **Sarvam ASR** — `SARVAM_API_KEY` required for `agentvoiceresponse/avr-asr-sarvam`
+* **Soniox ASR** — `SONIOX_API_KEY` required for `agentvoiceresponse/avr-asr-soniox`
+* **Compatibility matrix** — ASR rows documented in the Phase A connector matrix
+
+### Why this matters
+
+* **Fewer silent misconfigs** — missing ASR keys are rejected at provider create/update, not only at agent startup
+* **Connector parity** — backend contracts match `avr-asr-*` connector runtime requirements
+* **Operator clarity** — required env keys are listed in the published compatibility matrix
+
+### What has been updated
+
+* **avr-app** `1.5.6` — ASR provider runtime contracts (Deepgram, Sarvam, Soniox)
+  https://github.com/agentvoiceresponse/avr-app
 
 > 24 May 2026
 > {.is-info}

--- a/releases.md
+++ b/releases.md
@@ -36,6 +36,14 @@ Hi @everyone :wave:
 * **avr-app** `1.5.6` — ASR provider runtime contracts (Deepgram, Sarvam, Soniox)
   https://github.com/agentvoiceresponse/avr-app
 
+* **Updated guide:** AVR App – Administration Panel (ASR providers subsection)
+  https://wiki.agentvoiceresponse.com/en/administration-panel
+
+* **Updated guides:** Deepgram, Sarvam, Soniox ASR
+  https://wiki.agentvoiceresponse.com/en/deepgram
+  https://wiki.agentvoiceresponse.com/en/sarvam
+  https://wiki.agentvoiceresponse.com/en/avr-soniox-speech-to-text
+
 > 24 May 2026
 > {.is-info}
 {.is-info}


### PR DESCRIPTION
## Summary

Prepend public release notes for **avr-app 1.5.6** — ASR provider runtime contracts (Deepgram, Sarvam, Soniox).

Pairs with: agentvoiceresponse/avr-app ship PR for `avr-292-asr-provider-integration`.

Refs: AVR-292

## Test plan

- [ ] Wiki frontmatter date updated
- [ ] Merge after or with avr-app 1.5.6 ship PR


Made with [Cursor](https://cursor.com)