### PR TITLE
docs(AVR-300): update Gemini STS wiki for Vertex AI

### DIFF
--- a/using-gemini-sts-with-avr.md
+++ b/using-gemini-sts-with-avr.md
@@ -2,7 +2,7 @@
 title: Using Gemini STS with AVR
 description: 
 published: true
-date: 2026-05-08T15:17:52.208Z
+date: 2026-05-28T20:45:00.000Z
 tags: 
 editor: markdown
 dateCreated: 2025-09-02T13:38:04.526Z
@@ -30,17 +30,43 @@ This approach significantly **reduces latency** and enables more **natural, huma
 
 
 
-## Generate API Credentials
+## Authentication
 
-To connect AVR with Gemini, you need a Gemini API key:
+`avr-sts-gemini` **1.5.0+** supports two ways to authenticate with Gemini Live. Choose **one** mode per deployment — do not set an API key and Vertex flags together unless you intend Vertex mode (Vertex takes precedence when `GOOGLE_GENAI_USE_VERTEXAI=true`).
 
-1. Open **Google AI Studio**
+| Mode | Best for | Credentials |
+|------|----------|-------------|
+| **Google AI Studio** (default) | Quick setup, local dev | API key (`GEMINI_API_KEY` or `GOOGLE_API_KEY`) |
+| **Vertex AI** (Google Cloud Console) | GCP projects, service accounts, enterprise | Application Default Credentials (ADC) + project/region |
+
+Connector reference: https://github.com/agentvoiceresponse/avr-sts-gemini
+
+
+
+### Google AI Studio (API key)
+
+1. Open **Google AI Studio**: https://aistudio.google.com/apikey
 2. Sign in with your Google account
-3. Navigate to **API Keys**
-4. Create a new API key
-5. Copy and store it securely
+3. Create an API key and copy it securely
+4. Set `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) in your environment
 
-You will use this key as `GEMINI_API_KEY` in your Docker environment.
+No Google Cloud project is required for this path.
+
+
+
+### Vertex AI (Google Cloud Console)
+
+Use Vertex when Gemini is enabled in [Google Cloud Console](https://console.cloud.google.com/) instead of AI Studio.
+
+1. Create or select a **GCP project** with billing enabled
+2. Enable the **[Vertex AI API](https://console.cloud.google.com/flows/enableapi?apiid=aiplatform.googleapis.com)**
+3. Choose a **region** (for example `us-central1`) — set `GOOGLE_CLOUD_LOCATION` to match
+4. Configure **Application Default Credentials** using one of:
+   - **Service account (recommended for Docker):** create a key JSON file and set `GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json` (mount the file into the container)
+   - **Local development:** run `gcloud auth application-default login`
+5. Set Vertex mode environment variables (see tables below)
+
+Optional AVR-prefixed aliases: `GEMINI_USE_VERTEXAI`, `GEMINI_VERTEX_PROJECT`, `GEMINI_VERTEX_LOCATION`.
 
 
 
@@ -52,14 +78,38 @@ You will use this key as `GEMINI_API_KEY` in your Docker environment.
 
 ## Environment Variables
 
+### Shared (both modes)
+
 | Variable | Description | Example Value |
 |--------|-------------|---------------|
 | `PORT` | Port on which the Gemini STS service runs | `6037` |
-| `GEMINI_API_KEY` | API Key from Google AI Studio | `AIza...` |
-| `GEMINI_MODEL` | Gemini model ID to use | `gemini-2.5-flash-preview-native-audio-dialog` |
+| `GEMINI_MODEL` | Gemini model ID (Live native audio) | `gemini-2.5-flash-native-audio-preview-12-2025` |
+| `GEMINI_API_VERSION` | Optional API version override | *(unset)* |
 | `GEMINI_INSTRUCTIONS` | System prompt for the voice assistant | `"You are a helpful assistant."` |
 | `GEMINI_URL_INSTRUCTIONS` | URL to fetch dynamic instructions | `https://your-api.com/instructions` |
 | `GEMINI_FILE_INSTRUCTIONS` | Path to local instruction file | `./instructions.txt` |
+
+### Google AI Studio only
+
+| Variable | Required | Description | Example Value |
+|--------|----------|-------------|---------------|
+| `GEMINI_API_KEY` | Yes* | API key from Google AI Studio | `AIza...` |
+| `GOOGLE_API_KEY` | Yes* | Alternative name (Google GenAI SDK) | `AIza...` |
+
+\* One of `GEMINI_API_KEY` or `GOOGLE_API_KEY` is required. Do **not** set `GOOGLE_GENAI_USE_VERTEXAI=true` for AI Studio mode.
+
+### Vertex AI only
+
+| Variable | Required | Description | Example Value |
+|--------|----------|-------------|---------------|
+| `GOOGLE_GENAI_USE_VERTEXAI` | Yes | Enable Vertex AI mode | `true` |
+| `GOOGLE_CLOUD_PROJECT` | Yes | GCP project ID | `my-avr-project` |
+| `GOOGLE_CLOUD_LOCATION` | Yes | Vertex region | `us-central1` |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Yes† | Path to service account JSON (in container) | `/secrets/gcp-sa.json` |
+
+† Required in Docker/production unless the host provides ADC another way (e.g. GCE metadata).
+
+Aliases: `GEMINI_USE_VERTEXAI`, `GEMINI_VERTEX_PROJECT`, `GEMINI_VERTEX_LOCATION`.
 
 ### Gemini thinking settings
 
@@ -86,22 +136,58 @@ Supported values for `GEMINI_THINKING_LEVEL`:
 
 ## Docker Setup
 
+Pin the image tag in production (for example `1.5.0`). `:latest` tracks the newest release.
+
+### Google AI Studio
+
 Add the following service to your `docker-compose.yml`:
 
 ```yaml
 avr-sts-gemini:
-  image: agentvoiceresponse/avr-sts-gemini
+  image: agentvoiceresponse/avr-sts-gemini:1.5.0
   platform: linux/x86_64
   container_name: avr-sts-gemini
   restart: always
   environment:
     - PORT=6037
-    - GEMINI_API_KEY=$GEMINI_API_KEY
-    - GEMINI_MODEL=$GEMINI_MODEL
-    - GEMINI_INSTRUCTIONS=$GEMINI_INSTRUCTIONS
+    - GEMINI_API_KEY=${GEMINI_API_KEY}
+    - GEMINI_MODEL=${GEMINI_MODEL:-gemini-2.5-flash-native-audio-preview-12-2025}
+    - GEMINI_INSTRUCTIONS=${GEMINI_INSTRUCTIONS:-You are a helpful assistant}
+    - GEMINI_THINKING_LEVEL=${GEMINI_THINKING_LEVEL:-MINIMAL}
+    - GEMINI_THINKING_BUDGET=${GEMINI_THINKING_BUDGET:-0}
   networks:
     - avr
 ```
+
+
+
+### Vertex AI
+
+Mount a service account key and enable Vertex mode:
+
+```yaml
+avr-sts-gemini:
+  image: agentvoiceresponse/avr-sts-gemini:1.5.0
+  platform: linux/x86_64
+  container_name: avr-sts-gemini
+  restart: always
+  environment:
+    - PORT=6037
+    - GOOGLE_GENAI_USE_VERTEXAI=true
+    - GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}
+    - GOOGLE_CLOUD_LOCATION=${GOOGLE_CLOUD_LOCATION:-us-central1}
+    - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/gcp-sa.json
+    - GEMINI_MODEL=${GEMINI_MODEL:-gemini-2.5-flash-native-audio-preview-12-2025}
+    - GEMINI_INSTRUCTIONS=${GEMINI_INSTRUCTIONS:-You are a helpful assistant}
+  volumes:
+    - ${GOOGLE_APPLICATION_CREDENTIALS_HOST_PATH}:/run/secrets/gcp-sa.json:ro
+  networks:
+    - avr
+```
+
+Set `GOOGLE_APPLICATION_CREDENTIALS_HOST_PATH` in your `.env` to the JSON key path on the host (for example `./secrets/gcp-sa.json`).
+
+> If WebSocket init fails, the connector returns a specific `error` message (missing API key, project, or location) instead of a generic failure — check container logs and the message from `avr-core`.
 
 
 


### PR DESCRIPTION
## Summary

- Updates [Using Gemini STS with AVR](https://wiki.agentvoiceresponse.com/en/using-gemini-sts-with-avr) for `avr-sts-gemini` 1.5.0 dual auth
- Documents Google AI Studio (API key) vs Vertex AI (ADC + project/region)
- Adds env variable tables, Docker examples for both modes, and troubleshooting note for WebSocket init errors

## Test plan

- [ ] Wiki.js sync publishes `using-gemini-sts-with-avr.md` to the live page
- [ ] Vertex AI section matches connector README / `.env.example`


Made with [Cursor](https://cursor.com)